### PR TITLE
Add macOS binaries, update Anvil and Bor

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,10 @@
 avalanchego-linux-amd64-v1.8.5.tar.gz filter=lfs diff=lfs merge=lfs -text
 foundry_nightly_2022_09_20_linux_amd64.tar.gz filter=lfs diff=lfs merge=lfs -text
 bor-linux-amd64-v0.2.5.tar.gz filter=lfs diff=lfs merge=lfs -text
+bor_0.2.17_darwin_amd64.tar.gz filter=lfs diff=lfs merge=lfs -text
+bor_0.2.17_darwin_arm64.tar.gz filter=lfs diff=lfs merge=lfs -text
+bor_0.2.17_linux_amd64.tar.gz filter=lfs diff=lfs merge=lfs -text
+foundry_nightly_2022_10_19_darwin_amd64.tar.gz filter=lfs diff=lfs merge=lfs -text
+foundry_nightly_2022_10_19_darwin_arm64.tar.gz filter=lfs diff=lfs merge=lfs -text
+foundry_nightly_2022_10_19_linux_amd64.tar.gz filter=lfs diff=lfs merge=lfs -text
+avalanchego-macos-v1.8.5.zip filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,3 +8,4 @@ foundry_nightly_2022_10_19_darwin_amd64.tar.gz filter=lfs diff=lfs merge=lfs -te
 foundry_nightly_2022_10_19_darwin_arm64.tar.gz filter=lfs diff=lfs merge=lfs -text
 foundry_nightly_2022_10_19_linux_amd64.tar.gz filter=lfs diff=lfs merge=lfs -text
 avalanchego-macos-v1.8.5.zip filter=lfs diff=lfs merge=lfs -text
+avalanchego-macos-v1.8.5.tar.gz filter=lfs diff=lfs merge=lfs -text

--- a/avalanchego-macos-v1.8.5.tar.gz
+++ b/avalanchego-macos-v1.8.5.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b63b44a12fa06cdf98966667bb31234b93db18f4dfd6a0b8bf94a7baea6ccea9
+size 50174334

--- a/avalanchego-macos-v1.8.5.zip
+++ b/avalanchego-macos-v1.8.5.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2f08b67e86e80bd247c2ace99272f7a81b568debd674bc675fc689a43662fce
+size 50236750

--- a/avalanchego-macos-v1.8.5.zip
+++ b/avalanchego-macos-v1.8.5.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e2f08b67e86e80bd247c2ace99272f7a81b568debd674bc675fc689a43662fce
-size 50236750

--- a/bor-linux-amd64-v0.2.5.tar.gz
+++ b/bor-linux-amd64-v0.2.5.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6dce885844408950ac756f3ca31c7a8d5895b0c03ae720bcd5fc8880a8a25e3d
-size 20126044

--- a/bor_0.2.17_darwin_amd64.tar.gz
+++ b/bor_0.2.17_darwin_amd64.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:08c41ad0e98e0ecb8c6df50d3315216ec666e5a6acf734c00c1f127e7d3bc1ba
+size 12626137

--- a/bor_0.2.17_darwin_arm64.tar.gz
+++ b/bor_0.2.17_darwin_arm64.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27f24da003a56a6d2b609ec3ef8ae8a89ed35b82dcc06c8ec120966b1c5b4fdb
+size 12051122

--- a/bor_0.2.17_linux_amd64.tar.gz
+++ b/bor_0.2.17_linux_amd64.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8a5d97e9e93ff3785a34d65a874644ba8353b1e910f0639bcda32f33cbc3ffa8
+size 12983757

--- a/foundry_nightly_2022_09_20_linux_amd64.tar.gz
+++ b/foundry_nightly_2022_09_20_linux_amd64.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:4a0b9da74cfde4fdd431852ef00b709740b6981db0ff7602f7eb3ec4d652d6ec
-size 18296443

--- a/foundry_nightly_2022_10_19_darwin_amd64.tar.gz
+++ b/foundry_nightly_2022_10_19_darwin_amd64.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:87d9d0631245dd7d8ba74b89d516571f04a944551a92738acc6604d40c80fb0c
+size 18100343

--- a/foundry_nightly_2022_10_19_darwin_arm64.tar.gz
+++ b/foundry_nightly_2022_10_19_darwin_arm64.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9272b90734e43497b30acf2ae02f486949b70b371f2cc0668b09f9436a2124f2
+size 16119113

--- a/foundry_nightly_2022_10_19_linux_amd64.tar.gz
+++ b/foundry_nightly_2022_10_19_linux_amd64.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c1af9878e6b9720bee2d6c78d6ffba126642b662358762086ede11ea14b542c
+size 18531832


### PR DESCRIPTION
This change updates Anvil and Bor to ensure that we use the same versions for all platforms and because the older versions were not available for download anymore.