### PR TITLE
Update avalanchego to v1.9.1 for macOS

### DIFF
--- a/avalanchego-macos-amd64-v1.9.1.tar.gz
+++ b/avalanchego-macos-amd64-v1.9.1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e3e67b150d1acae214929a43c05c91daa59947aae2a1f3503ac9e22fa8955b9
+size 77452410

--- a/avalanchego-macos-arm64-v1.9.1.tar.gz
+++ b/avalanchego-macos-arm64-v1.9.1.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:928e8c15021ede46c49b14f3c879b1277336c1289ddb8e5ea5f372d6c52039f5
+size 76414957


### PR DESCRIPTION
Also adds the avalanche-network-runner v1.3.0 to the archives.